### PR TITLE
Allow configuring Bible and calendar API base URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
 API_BIBLE_KEY=your-api-bible-key
+API_BIBLE_BASE_URL=https://api.scripture.api.bible/v1
+ORTHOCAL_BASE_URL=https://orthocal.info/api

--- a/README.md
+++ b/README.md
@@ -8,11 +8,17 @@ Digital Kholagy is a multi-language Orthodox liturgical companion inspired by th
    ```bash
    npm install
    ```
-2. Copy the environment template and provide your API.Bible key:
+2. Copy the environment template and provide your API credentials/base URLs:
    ```bash
    cp .env.example .env
    ```
-   The `API_BIBLE_KEY` value is injected into the Expo runtime via `app.config.ts` and consumed through `expo-constants`.
+   Update the `.env` file with your keys (safe to keep the default base URLs unless you proxy the services):
+   ```
+   API_BIBLE_KEY=your_api_bible_key_here
+   API_BIBLE_BASE_URL=https://api.scripture.api.bible/v1
+   ORTHOCAL_BASE_URL=https://orthocal.info/api
+   ```
+   These values are injected into the Expo runtime via `app.config.ts` and consumed in the API clients through `expo-constants`.
 3. Generate the content map (re-run whenever you add or rename markdown files):
    ```bash
    npm run build:content
@@ -25,8 +31,8 @@ Digital Kholagy is a multi-language Orthodox liturgical companion inspired by th
 
 ## External Data Sources
 
-- **API.Bible** is used for the Holy Bible screen. Requests require the API key mentioned above and are routed through `src/api/bible.ts`. Books, chapters, verses, and search responses are cached in AsyncStorage so previously viewed passages remain available offline.
-- **Orthocal API** powers the liturgical calendar in `src/api/orthocal.ts`. Daily readings, feasts, and fast information are fetched for the selected date and cached to provide an offline history.
+- **API.Bible** is used for the Holy Bible screen. Requests require the API key mentioned above and are routed through `src/api/bible.ts`, which reads the base URL from `API_BIBLE_BASE_URL`. Books, chapters, verses, and search responses are cached in AsyncStorage so previously viewed passages remain available offline.
+- **Orthocal API** powers the liturgical calendar in `src/api/orthocal.ts`. Daily readings, feasts, and fast information are fetched for the selected date, using the `ORTHOCAL_BASE_URL` to build requests, and cached to provide an offline history.
 - Local markdown liturgy texts are wrapped by `src/api/liturgy.ts`, which ReaderScreen now consumes to keep markdown loading logic consistent with the network APIs.
 
 ## Navigation & Menu Updates
@@ -37,7 +43,7 @@ Digital Kholagy is a multi-language Orthodox liturgical companion inspired by th
 
 ## Offline Caching
 
-- Bible queries (books, chapters, verses, search results) persist in AsyncStorage for quick repeat access.
+- Bible queries (books, chapters, verses, search results) persist in AsyncStorage for quick repeat access and gracefully fall back to the cached payload when the network is unavailable.
 - Calendar responses cache per date for 12 hours, ensuring daily readings remain available even when offline.
 - Liturgy scroll position bookmarks continue to save automatically; copy/share actions now surface quick toasts.
 

--- a/app.config.ts
+++ b/app.config.ts
@@ -23,12 +23,15 @@ if (fs.existsSync(envPath)) {
 }
 
 export default (): ExpoConfig => {
-  const base = appJson.expo ?? {};
+  const baseConfig = (appJson.expo ?? {}) as ExpoConfig;
+  const baseExtra = (baseConfig.extra ?? {}) as Record<string, unknown>;
   return {
-    ...base,
+    ...baseConfig,
     extra: {
-      ...(base.extra ?? {}),
+      ...baseExtra,
       apiBibleKey: process.env.API_BIBLE_KEY ?? '',
+      apiBibleBaseUrl: process.env.API_BIBLE_BASE_URL ?? 'https://api.scripture.api.bible/v1',
+      orthocalBaseUrl: process.env.ORTHOCAL_BASE_URL ?? 'https://orthocal.info/api',
     },
   } as ExpoConfig;
 };

--- a/src/api/bible.ts
+++ b/src/api/bible.ts
@@ -7,7 +7,20 @@ export const DEFAULT_BIBLE_IDS: Record<string, string> = {
   ru: 'c9e485b1eb295f0c-01', // Synodal Russian Bible
 };
 
-const API_ROOT = 'https://api.scripture.api.bible/v1';
+const DEFAULT_API_ROOT = 'https://api.scripture.api.bible/v1';
+
+const resolveApiRoot = () => {
+  const fromExtra =
+    (Constants.expoConfig?.extra as any)?.apiBibleBaseUrl ??
+    (Constants.manifest as any)?.extra?.apiBibleBaseUrl ??
+    (typeof process !== 'undefined' ? process.env.API_BIBLE_BASE_URL : undefined);
+  if (typeof fromExtra === 'string' && fromExtra.trim().length > 0) {
+    return fromExtra.trim().replace(/\/+$/, '');
+  }
+  return DEFAULT_API_ROOT;
+};
+
+const API_ROOT = resolveApiRoot();
 const CACHE_TTL_BOOKS = 1000 * 60 * 60 * 24; // 24 hours
 const CACHE_TTL_CHAPTERS = 1000 * 60 * 60 * 12; // 12 hours
 const CACHE_TTL_VERSES = 1000 * 60 * 60 * 6; // 6 hours

--- a/src/api/orthocal.ts
+++ b/src/api/orthocal.ts
@@ -1,6 +1,22 @@
+import Constants from 'expo-constants';
 import { fetchWithCache } from './cache';
 
-const API_ROOT = 'https://orthocal.info/api/oca';
+const DEFAULT_API_ROOT = 'https://orthocal.info/api';
+
+const joinUrl = (base: string, path: string) => `${base.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`;
+
+const resolveApiRoot = () => {
+  const fromExtra =
+    (Constants.expoConfig?.extra as any)?.orthocalBaseUrl ??
+    (Constants.manifest as any)?.extra?.orthocalBaseUrl ??
+    (typeof process !== 'undefined' ? process.env.ORTHOCAL_BASE_URL : undefined);
+  if (typeof fromExtra === 'string' && fromExtra.trim().length > 0) {
+    return fromExtra.trim().replace(/\/+$/, '');
+  }
+  return DEFAULT_API_ROOT;
+};
+
+const API_ROOT = joinUrl(resolveApiRoot(), 'oca');
 const CACHE_TTL_DAY = 1000 * 60 * 60 * 12; // 12 hours
 
 type QueryParams = Record<string, string | number | undefined>;
@@ -16,7 +32,7 @@ const toDateParam = (input: Date | string): string => {
 };
 
 const buildUrl = (path: string, params: QueryParams = {}) => {
-  const url = new URL(`${API_ROOT}${path}`);
+  const url = new URL(joinUrl(API_ROOT, path));
   Object.entries(params).forEach(([key, value]) => {
     if (value === undefined || value === null) {
       return;


### PR DESCRIPTION
## Summary
- allow Expo extra configuration to expose API.Bible and Orthocal base URLs alongside the API key
- update the Scripture and calendar API clients to read configurable roots with AsyncStorage caching fallbacks
- document the environment variables in the README and template so developers know how to configure the services

## Testing
- `npx tsc --noEmit` *(fails: existing navigation types expect a tab named "home" and restrict menu navigation overloads)*

------
https://chatgpt.com/codex/tasks/task_e_68d14968dfbc8329a68f6e41999cfa65